### PR TITLE
Display message when no layouts are found in category or search page

### DIFF
--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -7,19 +7,22 @@
   </div>
 </div>
 
-<div class="sort-tabs-wrapper">
-  <%= render 'recipes/sort_tabs' %>
-</div>
-
-<div class="container">
-  <div id="recipes-list">
-    <%= render 'recipes/recipe_list', recipes: @recipes %>
+<% if @recipes.present? %>
+  <div class="sort-tabs-wrapper">
+    <%= render 'recipes/sort_tabs' %>
   </div>
-</div>
 
-<div class="pagination-wrapper mt-4">
-  <div class="d-flex justify-content-center">
-    <%= paginate @recipes if @recipes.respond_to?(:total_pages) %>
+  <div class="container">
+    <div id="recipes-list">
+      <%= render 'recipes/recipe_list', recipes: @recipes %>
+    </div>
   </div>
-</div>
 
+  <div class="pagination-wrapper mt-4">
+    <div class="d-flex justify-content-center">
+      <%= paginate @recipes if @recipes.respond_to?(:total_pages) %>
+    </div>
+  </div>
+<% else %>
+  <p class="text-center mt-4">まだレイアウトの投稿はありません。</p>
+<% end %>

--- a/app/views/recipes/search.html.erb
+++ b/app/views/recipes/search.html.erb
@@ -1,5 +1,5 @@
 <div class="recipe-index-wrapper">
-<h1 class="page-title mb-4 fs-2">検索結果</h1>
+  <h1 class="page-title mb-4 fs-2">検索結果</h1>
   <p class="post-count">検索結果: <%= @total_recipes_count %> 件見つかりました。</p>
 
   <div class="search-form-wrapper">
@@ -7,18 +7,22 @@
   </div>
 </div>
 
-<div class="sort-tabs-wrapper">
-  <%= render 'recipes/sort_tabs' %>
-</div>
-
-<div class="container">
-  <div id="recipes-list">
-    <%= render 'recipes/recipe_list', recipes: @recipes %>
+<% if @recipes.present? %>
+  <div class="sort-tabs-wrapper">
+    <%= render 'recipes/sort_tabs' %>
   </div>
-</div>
 
-<div class="pagination-wrapper mt-4">
-  <div class="d-flex justify-content-center">
-    <%= paginate @recipes if @recipes.respond_to?(:total_pages) %>
+  <div class="container">
+    <div id="recipes-list">
+      <%= render 'recipes/recipe_list', recipes: @recipes %>
+    </div>
   </div>
-</div>
+
+  <div class="pagination-wrapper mt-4">
+    <div class="d-flex justify-content-center">
+      <%= paginate @recipes if @recipes.respond_to?(:total_pages) %>
+    </div>
+  </div>
+<% else %>
+  <p class="text-center mt-4">条件に一致する検索はありません。</p>
+<% end %>


### PR DESCRIPTION
お疲れ様です。対象のレウアウトが無い場合の表示に関して、編集をしました。
具体的には以下です。

・対象のカテゴリのレイアウトが無い場合、「まだレイアウトの投稿はありません。」という表示に変更。
・検索条件に一致したレイアウトが無い場合、「条件に一致する検索はありません。」という表示に変更。
・上記どちらの場合もソートタブボタンが表示されていましたが、表示されないように変更。

ご確認のほど、よろしくお願いします。