### PR TITLE
Style: unify password reset layout, apply i18n, add shared button style

### DIFF
--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,31 @@
-<h2>Forgot your password?</h2>
-
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<nav class="breadcrumbs">
+  <div class="breadcrumbs-inner">
+    <%= link_to "ホーム", root_path %> &gt;
+    <span>パスワード再設定</span>
   </div>
+</nav>
 
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
+<main class="login-form-wrapper mx-auto" style="max-width: 500px; padding-top: 100px;">
+  <h1 class="page-title mb-4 fs-2">パスワード再設定</h1>
 
-<%= render "devise/shared/links" %>
+  <p class="mb-3">入力したメールアドレスに再設定用リンクをお送りします。</p>
+
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+
+    <div class="mb-3">
+      <label class="form-label fw-bold" for="user_email">メールアドレス</label>
+      <span class="text-danger small ms-2">必須</span>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control", id: "user_email" %>
+    </div>
+
+    <div class="d-grid">
+      <%= f.submit t("devise.passwords.new.send_me_reset_password_instructions"),
+            class: "btn-green" %>
+    </div>
+  <% end %>
+
+  <div class="mt-3">
+    <%= render "devise/shared/links" %>
+</main>
+<div style="height: 150px;"></div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,5 +1,4 @@
 <main class="login-form-wrapper mx-auto" style="max-width: 500px; padding-top: 100px;">
-
 <h1 class="page-title mb-4 fs-2">ログイン</h1>
 
   <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
@@ -24,7 +23,7 @@
   <% end %>
 
     <div class="d-grid">
-      <%= f.submit "ログインする", class: "btn btn-success py-2 rounded-pill fw-bold" %>
+      <%= f.submit "ログインする", class: "btn-green" %>
     </div>
   <% end %>
 

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,12 +1,12 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
-    <h2>
-      <%= I18n.t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
-    </h2>
-    <ul>
+  <div id="error_explanation" class="alert alert-danger" data-turbo-cache="false">
+    <h5 class="fs-6 fw-bold text-danger">
+    <%= I18n.t("errors.messages.not_saved.one",
+    count: resource.errors.count,
+    resource: resource.class.model_name.human.downcase)
+    %>
+    </h5>
+    <ul class="list-unstyled small">
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,7 @@
     <%= render 'layouts/flash' %>
 
     <main class="main-content">
-      <% unless current_page?(root_path) %>
+      <% unless current_page?(root_path) || controller_name == 'passwords' %>
         <%= render 'shared/breadcrumbs' %>
       <% end %>
 

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -31,7 +31,7 @@
     </div>
 
     <div class="d-grid">
-      <%= f.submit "新規登録する", class: "btn btn-success py-2 rounded-pill fw-bold" %>
+      <%= f.submit "新規登録する", class: "btn-green" %>
     </div>
   <% end %>
 

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -84,7 +84,7 @@ ja:
         new_password: 新しいパスワード
       new:
         forgot_your_password: パスワードを忘れましたか？
-        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+        send_me_reset_password_instructions: パスワード再設定メールを送信する
       no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
       send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
       send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
@@ -141,5 +141,5 @@ ja:
       not_found: は見つかりませんでした。
       not_locked: はロックされていません。
       not_saved:
-        one: エラーが発生したため %{resource} は保存されませんでした。
+        one: "パスワード再設定に失敗しました。"
         other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -14,3 +14,18 @@ ja:
       previous: "前へ"
       next: "次へ"
       truncate: "..."
+  
+  activerecord:
+    models:
+      user: ユーザー
+    attributes:
+      user:
+        email: メールアドレス
+        password: パスワード
+        password_confirmation: パスワード（確認）
+
+  errors:
+    messages:
+      blank: "を入力してください。"
+      invalid: "が正しくありません"
+      too_short: "は%{count}文字以上で入力してください"


### PR DESCRIPTION
お疲れ様です。
パスワード再設定画面の修正を以下のように行いました。
・レイアウトをログイン画面と同系統に修正。
・エラー時のメッセージの日本語化。
・エラー時のメッセージ内容を「パスワード再設定に失敗しました。」、背景を赤色に変更。

ご確認のほど、よろしくお願いします。