### PR TITLE
Fix footer overlap issue when no recipes or favorites are present

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -46,3 +46,6 @@
   height: auto;
 }
   
+.empty-space {
+  height: 200px;
+}

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -48,8 +48,9 @@
     <% end %>
   </ul>
 <% else %>
-  <p class="no-recipes-message">お気に入りのレイアウトはありません。</p>
+  <div class="empty-space">
+    <p class="no-recipes-message">お気に入りのレイアウトはありません。</p>
+  </div>
 <% end %>
-
 <%= image_tag("ham.png", class: "users-recipepage-image") %>
 </main>

--- a/app/views/users/recipes.html.erb
+++ b/app/views/users/recipes.html.erb
@@ -49,7 +49,9 @@
     <% end %>
   </ul>
 <% else %>
-  <p class="no-recipes-message">まだレシピを投稿していません。</p>
+  <div class="empty-space">
+    <p class="no-recipes-message">まだレシピを投稿していません。</p>
+  </div>
 <% end %>
 <%= image_tag("ham.png", class: "users-recipepage-image") %>
 </main>


### PR DESCRIPTION
お疲れ様です。
マイレイアウト、お気に入り一覧ページにてレイアウトが1つも無い時、レイアウトの崩れがあった為修正しました。
内容は以下です。

・フッターが上に上がり画像とかぶっていた為、ダミーの空間を配置し、適切な場所に配置されるように修正。
