### PR TITLE
Fix issue where only paginated count (9) was displayed instead of tot…

### DIFF
--- a/app/services/recipes/fetcher.rb
+++ b/app/services/recipes/fetcher.rb
@@ -16,7 +16,10 @@ module Recipes
       apply_search
       apply_filters
       apply_sorting
-      @recipes.includes(:category, :likes).page(params[:page]).per(9)
+
+      @total_count = @recipes.count
+
+      @recipes = @recipes.includes(:category, :likes).page(params[:page]).per(9)
     end
 
     private

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -1,6 +1,6 @@
 <div class="recipe-index-wrapper">
 <h1 class="page-title mb-4 fs-2">投稿一覧</h1>
-<p class="post-count">投稿件数: <%= @total_recipes_count %> 件</p>
+<p class="post-count">投稿件数: <%= @recipes.total_count %> 件</p>
   <div class="search-form-wrapper">
     <%= render 'shared/search_form_category' %>
   </div>

--- a/app/views/recipes/search.html.erb
+++ b/app/views/recipes/search.html.erb
@@ -1,6 +1,6 @@
 <div class="recipe-index-wrapper">
   <h1 class="page-title mb-4 fs-2">検索結果</h1>
-  <p class="post-count">検索結果: <%= @total_recipes_count %> 件見つかりました。</p>
+  <p class="post-count">検索結果: <%= @recipes.total_count %> 件見つかりました。</p>
 
   <div class="search-form-wrapper">
     <%= render 'shared/search_form_category' %>


### PR DESCRIPTION
お疲れ様です。
投稿一覧ページで投稿件数の表示が総数ではなく、ページネーションの設定数である"9件"ずつの表示になっていたので
この問題を修正しました。また検索結果数も同様に修正いたしました。
ご確認のほどよろしくお願いいたします。