### PR TITLE
ゲストユーザーに通常ユーザーと同等の機能を付与

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,8 +1,7 @@
 # favorites_controller はお気に入り機能の管理をするコントローラーです。
 class FavoritesController < ApplicationController
   before_action :authenticate_user!
-  before_action :reject_guest_user, only: [:create, :destroy]
-
+  
   def index
     add_breadcrumb("お気に入り一覧")
 
@@ -33,11 +32,5 @@ class FavoritesController < ApplicationController
     else
       render json: { status: "error", message: "お気に入り解除に失敗しました。" }
     end
-  end
-
-  private
-
-  def reject_guest_user
-    render json: { status: "error", message: "ゲストユーザーはお気に入りできません。" }, status: :forbidden if current_user.guest?
   end
 end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,7 +1,6 @@
 # LikesController は「いいね」の操作を管理するコントローラーです。
 class LikesController < ApplicationController
   before_action :authenticate_user!
-  before_action :reject_guest_user
   before_action :set_recipe, only: [:create, :destroy]
 
   def create
@@ -30,11 +29,5 @@ class LikesController < ApplicationController
 
   def set_recipe
     @recipe = Recipe.find(params[:recipe_id])
-  end
-
-  def reject_guest_user
-    return unless current_user.guest?
-
-    render json: { status: "error" }, status: :forbidden
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -6,6 +6,7 @@ module Users
     before_action :authenticate_user!, only: [:show]
     before_action :set_new_breadcrumb, only: [:new, :create]
     before_action :set_breadcrumbs_for_edit, only: [:edit, :update]
+    before_action :reject_guest_user, only: [:edit, :update]
 
     def show
       add_breadcrumb("アカウント情報")
@@ -32,6 +33,12 @@ module Users
     def set_breadcrumbs_for_edit
       add_breadcrumb("アカウント情報", account_path)
       add_breadcrumb("アカウント編集")
+    end
+
+    def reject_guest_user
+      if current_user&.guest?
+        redirect_to root_path, alert: "ゲストユーザーはアカウントの編集はできません。"
+      end
     end
   end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -24,13 +24,11 @@
               <strong><%= current_user.name %></strong>
             </a>
             <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="dropdownUser">
-              <% unless current_user.guest? %>
                 <li><%= link_to "アカウント情報", account_path, class: "dropdown-item" %></li>
                 <li><%= link_to "プロフィール", current_user, class: "dropdown-item" %></li>
                 <li><%= link_to "マイレイアウト", recipes_user_path(current_user), class: "dropdown-item" %></li>
                 <li><%= link_to "お気に入り一覧", favorites_path, class: "dropdown-item" %></li>
                 <li><hr class="dropdown-divider"></li>
-              <% end %>
               <li><%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "dropdown-item" %></li>
             </ul>
           </div>

--- a/app/views/recipes/_favorite_button.html.erb
+++ b/app/views/recipes/_favorite_button.html.erb
@@ -1,15 +1,9 @@
 <% if recipe.user != current_user %>
   <% if user_signed_in? %>
-    <% if current_user.guest? %>
-      <button class="favorite-button recipe-action-button guest-user">
-        <i class="fa-regular fa-star"></i>
-      </button>
-    <% else %>
-      <% favorite = current_user.favorites.find_by(recipe: recipe) %>
-      <button class="favorite-button recipe-action-button" data-url="<%= recipe_favorite_path(recipe) %>" data-method="<%= favorite ? 'delete' : 'post' %>">
-        <i class="<%= favorite ? 'fa-solid fa-star' : 'fa-regular fa-star' %>" style="<%= favorite ? 'color: gold;' : '' %>"></i>
-      </button>
-    <% end %>
+    <% favorite = current_user.favorites.find_by(recipe: recipe) %>
+    <button class="favorite-button recipe-action-button" data-url="<%= recipe_favorite_path(recipe) %>" data-method="<%= favorite ? 'delete' : 'post' %>">
+      <i class="<%= favorite ? 'fa-solid fa-star' : 'fa-regular fa-star' %>" style="<%= favorite ? 'color: gold;' : '' %>"></i>
+    </button>
   <% else %>
     <button class="favorite-button recipe-action-button guest-user">
       <i class="fa-regular fa-star"></i>

--- a/app/views/recipes/_like_button.html.erb
+++ b/app/views/recipes/_like_button.html.erb
@@ -1,4 +1,4 @@
-<% if current_user && !current_user.guest? %>
+<% if user_signed_in? %>
   <% if current_user.liked?(recipe) %>
     <button class="like-button recipe-action-button" data-url="<%= recipe_like_path(recipe) %>" data-method="delete">
       <i class="fa-solid fa-heart" style="color: red;"></i> <span class="like-count"><%= recipe.likes.count %></span>
@@ -9,7 +9,8 @@
     </button>
   <% end %>
 <% else %>
-  <div>
+  <button class="like-button recipe-action-button guest-user">
     <i class="fa-regular fa-heart"></i> <span class="like-count"><%= recipe.likes.count %></span>
-  </div>
+  </button>
 <% end %>
+

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -67,7 +67,7 @@
       <%= render "recipes/favorite_button", recipe: @recipe %>
     </div>
 
-    <% if current_user && current_user == @recipe.user && !current_user.guest? %>
+    <% if current_user && current_user == @recipe.user %>
       <div class="d-flex justify-content-start mb-3 gap-2">
         <%= link_to "編集", edit_recipe_path(@recipe), class: "btn-green" %>
         <%= link_to "削除", recipe_path(@recipe), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn-cancel" %>

--- a/app/views/users/registrations/show.html.erb
+++ b/app/views/users/registrations/show.html.erb
@@ -17,9 +17,11 @@
       <div><%= current_user.created_at.strftime("%Y年%m月%d日") %></div>
     </div>
 
-    <div class="text-end mt-4">
-      <%= link_to "編集する", edit_user_registration_path, class: "btn-green" %>
-    </div>
+    <% unless current_user.guest? %>
+      <div class="text-end mt-4">
+        <%= link_to "編集する", edit_user_registration_path, class: "btn-green" %>
+      </div>
+    <% end %>
   </div>
 </div>
 <%= image_tag("leopa3.png", class: "bottom-image") %>

--- a/spec/systems/guest_spec.rb
+++ b/spec/systems/guest_spec.rb
@@ -1,10 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe 'ゲストログイン機能', type: :system do
-  let(:guest_user) do
+  let!(:guest_user) do
     User.find_by(email: "guest@example.com") ||
       create(:user, email: "guest@example.com", name: "ゲストユーザー")
   end
+
   let!(:category) { create(:category, name: "爬虫類") }
   let!(:recipe) { create(:recipe, user: guest_user, category: category) }
 
@@ -24,34 +25,48 @@ RSpec.describe 'ゲストログイン機能', type: :system do
     end
 
     describe '投稿関連' do
-      it '編集ボタンが表示されない' do
+      before { visit recipe_path(recipe) }
+
+      it '編集ボタンが表示される' do
         visit recipe_path(recipe)
-        expect(page).not_to have_link('編集')
+        expect(page).to have_link('編集')
       end
 
-      it '削除ボタンが表示されない' do
+      it '削除ボタンが表示される' do
         visit recipe_path(recipe)
-        expect(page).not_to have_link('削除')
+        expect(page).to have_link('削除')
       end
     end
 
-    describe 'ヘッダーメニューの表示制限' do
+    describe 'ヘッダーメニューの表示' do
       before { find('.dropdown-toggle').click }
 
-      it 'アカウント情報が表示されない' do
-        expect(page).not_to have_link('アカウント情報')
+      it 'アカウント情報が表示される' do
+        expect(page).to have_link('アカウント情報')
       end
 
-      it 'プロフィールが表示されない' do
-        expect(page).not_to have_link('プロフィール')
+      it 'プロフィールが表示される' do
+        expect(page).to have_link('プロフィール')
       end
 
-      it 'マイレイアウトが表示されない' do
-        expect(page).not_to have_link('マイレイアウト')
+      it 'マイレイアウトが表示される' do
+        expect(page).to have_link('マイレイアウト')
       end
 
-      it 'お気に入り一覧が表示されない' do
-        expect(page).not_to have_link('お気に入り一覧')
+      it 'お気に入り一覧が表示される' do
+        expect(page).to have_link('お気に入り一覧')
+      end
+    end
+
+    describe '編集ページアクセス制限' do
+      before { visit edit_user_registration_path }
+
+      it 'root_path にリダイレクトされる' do
+        expect(current_path).to eq(root_path)
+      end
+
+      it '警告メッセージが表示される' do
+        expect(page).to have_content('ゲストユーザーはアカウントの編集はできません。')
       end
     end
 


### PR DESCRIPTION
お疲れ様です。
ゲストログイン時、通常ユーザーと同等の機能を付与するように実装しました。
以下、変更いたしました。
・ヘッダーメニューの表示(アカウント情報、プロフィール、マイレイアウト、お気に入り一覧)
・ゲストユーザーの投稿の編集、削除
・いいね、お気に入り機能の利用

ご確認のほど、よろしくお願いいたします。