### PR TITLE
一覧ページのユーザー名横にユーザーアイコンを表示とプロフィールのアイコンの大きさ調整

### DIFF
--- a/app/assets/stylesheets/recipes_show.scss
+++ b/app/assets/stylesheets/recipes_show.scss
@@ -75,6 +75,12 @@
   height: 35px;
 }
 
+.user-profile-avatar {
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+}
+
 .label-description-box {
   max-width: 90%;
   width: 800px;

--- a/app/views/recipes/_recipe.html.erb
+++ b/app/views/recipes/_recipe.html.erb
@@ -12,7 +12,14 @@
       <h5 class="card-title">
         <%= link_to recipe.title, recipe_path(recipe), class: "text-decoration-none text-dark" %>
       </h5>
-      <p class="card-text small"><%= link_to recipe.user.name, user_path(recipe.user) %></p>
+      <p class="card-text small d-flex align-items-center">
+        <% if recipe.user.avatar.attached? %>
+          <%= image_tag recipe.user.avatar, class: "user-avatar me-2", alt: "投稿者アイコン" %>
+        <% else %>
+          <%= image_tag "no-man.png", class: "user-avatar me-2", alt: "デフォルトアイコン" %>
+        <% end %>
+        <%= link_to recipe.user.name, user_path(recipe.user), class: "text-decoration-none" %>
+      </p>
       <p class="card-text small text-muted"><%= recipe.created_at.strftime("%Y-%m-%d %H:%M") %></p>
 
       <div class="d-flex justify-content-start gap-3 mt-2">

--- a/app/views/users/recipes.html.erb
+++ b/app/views/users/recipes.html.erb
@@ -35,6 +35,7 @@
             <div class="users-recipe-actions">
               <div class="users-recipe-like">
                 <%= render "recipes/like_button", recipe: recipe %>
+                <%= render "recipes/favorite_button", recipe: recipe %>
               </div>
             <% if current_user == recipe.user %>
               <div class="users-recipe-edit-delete">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,9 +6,9 @@
         <div class="fw-bold me-3" style="min-width: 100px;">アイコン</div>
         <div>
           <% if @user.avatar.attached? %>
-            <%= image_tag @user.avatar, class: "user-avatar", alt: "プロフィール画像" %>
+            <%= image_tag @user.avatar, class: "user-profile-avatar", alt: "プロフィール画像" %>
           <% else %>
-            <%= image_tag "no-man.png",  class: "user-avatar", alt: "デフォルトプロフィール画像" %>
+            <%= image_tag "no-man.png",  class: "user-profile-avatar", alt: "デフォルトプロフィール画像" %>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
お疲れ様です。
投稿一覧にて、それぞれの投稿にある投稿ユーザ名の左側にアイコンを表示させるように編集しました。
またプロフィール画面でアイコンの大きさが小さかった為、見やすいように大きく調整しました。

ご確認のほど、よろしくお願いいたします。